### PR TITLE
Use yaml-cpp string values

### DIFF
--- a/src/sysc/scc/configurer.cpp
+++ b/src/sysc/scc/configurer.cpp
@@ -502,6 +502,18 @@ struct yaml_config_reader : public config_reader {
                                 broker.set_preset_cci_value(hier_name, cci::cci_value(res.value()));
                             }
                         }
+                    } else if (tag.size() && tag[0] == '!') {
+                        auto param_handle = broker.get_param_handle(hier_name);
+                        if(param_handle.is_valid()) {
+                            auto param = param_handle.get_cci_value();
+                            if(param.is_string()) {
+                                param.set_string(val.as<std::string>());
+                            }
+                        } else {
+                            if(auto res = YAML::as_if<std::string, optional<std::string>>(val)()) {
+                                broker.set_preset_cci_value(hier_name, cci::cci_value(res.value()));
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
In YAML, string values get the "!" tag, which was ignored in the configurer. This adds handling of string values from config files.
I just assumed that strings are not parsed further and just written into string parameters.